### PR TITLE
Fixed the product upsertion for the emulated admin store scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### 2.10.0
 * Add support for sending following attributes to Nosto
- ``* rating and reviews data to Nosto (Magento native ratings and Yotpo)
+ * rating and reviews data to Nosto (Magento native ratings and Yotpo)
  * alternative images
  * inventory level
  * supplier cost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 2.11.2
+* Fixed a bug that caused issues when flat tables were enabled and a product was updated from the main store scope
+
 ### 2.11.1
 * Add support for Magento core modules version 1.9.3.2
 
@@ -8,7 +11,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### 2.10.0
 * Add support for sending following attributes to Nosto
- * rating and reviews data to Nosto (Magento native ratings and Yotpo)
+ ``* rating and reviews data to Nosto (Magento native ratings and Yotpo)
  * alternative images
  * inventory level
  * supplier cost

--- a/app/code/community/Nosto/Tagging/Helper/Class.php
+++ b/app/code/community/Nosto/Tagging/Helper/Class.php
@@ -35,6 +35,18 @@
 class Nosto_Tagging_Helper_Class extends Mage_Core_Helper_Abstract
 {
     /*
+     * Default class for order handling
+     */
+    const DEFAULT_ORDER_CLASS = 'nosto_tagging/meta_order';
+
+    /*
+     * Supported payment providers with custom order handling
+     */
+    public static $paymentProviderClasses = array(
+        'nosto_tagging/meta_order_vaimo_klarna_checkout'
+    );
+
+    /*
      * Loads correct / plugable order class based on payment provider
      *
      * @param Mage_Sales_Model_Order $order
@@ -52,15 +64,18 @@ class Nosto_Tagging_Helper_Class extends Mage_Core_Helper_Abstract
         if (is_object($payment)) {
             $paymentProvider = $payment->getMethod();
         }
-        $classId = sprintf(
-            'nosto_tagging/meta_order_%s',
-            $paymentProvider
-        );
-        return $this->getClass(
-            $classId,
-            'NostoOrderInterface',
-            'nosto_tagging/meta_order'
-        );
+        $classId = self::createClassId('meta_order_%s', $paymentProvider);
+        if (!in_array($classId, self::$paymentProviderClasses)) {
+            $class = Mage::getModel(self::DEFAULT_ORDER_CLASS);
+        } else {
+            $class = $this->getClass(
+                $classId,
+                'NostoOrderInterface',
+                self::DEFAULT_ORDER_CLASS
+            );
+        }
+
+        return $class;
     }
 
     /*

--- a/app/code/community/Nosto/Tagging/Model/Meta/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Meta/Product.php
@@ -225,6 +225,17 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Tagging_Model_Base implemen
     }
 
     /**
+     * Reloads the product info from a Magento product model.
+     *
+     * @param Mage_Catalog_Model_Product $product the product model to reload
+     * @param Mage_Core_Model_Store|null $store the store to get the product data for.
+     */
+    public function reloadData(Mage_Catalog_Model_Product $product, Mage_Core_Model_Store $store = null)
+    {
+        $this->loadData(Mage::getModel('catalog/product')->load($product->getId()), $store);
+    }
+
+    /**
      * Loads the product info from a Magento product model.
      *
      * @param Mage_Catalog_Model_Product $product the product model.

--- a/app/code/community/Nosto/Tagging/Model/Meta/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Meta/Product.php
@@ -230,9 +230,12 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Tagging_Model_Base implemen
      * @param Mage_Catalog_Model_Product $product the product model to reload
      * @param Mage_Core_Model_Store|null $store the store to get the product data for.
      */
-    public function reloadData(Mage_Catalog_Model_Product $product, Mage_Core_Model_Store $store = null)
+    public function reloadData(Mage_Catalog_Model_Product $product, Mage_Core_Model_Store $store)
     {
-        $this->loadData(Mage::getModel('catalog/product')->load($product->getId()), $store);
+        $reloadedProduct = Mage::getModel('catalog/product')
+            ->setStoreId($store->getId())
+            ->load($product->getId());
+        $this->loadData($reloadedProduct, $store);
     }
 
     /**

--- a/app/code/community/Nosto/Tagging/Model/Observer.php
+++ b/app/code/community/Nosto/Tagging/Model/Observer.php
@@ -118,15 +118,17 @@ class Nosto_Tagging_Model_Observer
                 /* @var Mage_Core_Model_App_Emulation $emulation */
                 $emulation = Mage::getSingleton('core/app_emulation');
                 $env = $emulation->startEnvironmentEmulation($store->getId());
-                /** @var Nosto_Tagging_Model_Meta_Product $model */
-                $model = Mage::getModel('nosto_tagging/meta_product');
-                $model->setProductId($product->getId());
                 try {
+                    /** @var Nosto_Tagging_Model_Meta_Product $model */
+                    $model = Mage::getModel('nosto_tagging/meta_product');
+                    $model->setProductId($product->getId());
                     $service = new NostoOperationProduct($account);
                     $service->addProduct($model);
                     $service->delete();
                 } catch (NostoException $e) {
                     Mage::log("\n" . $e, Zend_Log::ERR, Nosto_Tagging_Model_Base::LOG_FILE_NAME);
+                } catch (Exception $e) {
+                    Mage::logException($e);
                 }
                 $emulation->stopEnvironmentEmulation($env);
             }

--- a/app/code/community/Nosto/Tagging/Model/Service/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Service/Product.php
@@ -104,10 +104,11 @@ class Nosto_Tagging_Model_Service_Product
             foreach ($productBatches as $productsInStore) {
                 try {
                     $service = new NostoOperationProduct($account);
+                    /* @var $mageProduct Mage_Catalog_Model_Product */
                     foreach ($productsInStore as $mageProduct) {
                         /** @var Nosto_Tagging_Model_Meta_Product $nostoProduct */
                         $nostoProduct = Mage::getModel('nosto_tagging/meta_product');
-                        // If the current store scope if the main store scope, also referred to as
+                        // If the current store scope is the main store scope, also referred to as
                         // the admin store scope, then we should reload the product as the store
                         // code of the product refers to an pseudo store scope called "admin"
                         // which leads to issues when flat tables are enabled.

--- a/app/code/community/Nosto/Tagging/Model/Service/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Service/Product.php
@@ -111,11 +111,7 @@ class Nosto_Tagging_Model_Service_Product
                         // the admin store scope, then we should reload the product as the store
                         // code of the product refers to an pseudo store scope called "admin"
                         // which leads to issues when flat tables are enabled.
-                        if (Mage::app()->getStore() === Mage_Core_Model_App::ADMIN_STORE_ID) {
-                            $nostoProduct->reloadData($mageProduct, $store); // Note the reload
-                        } else {
-                            $nostoProduct->loadData($mageProduct, $store);
-                        }
+                        $nostoProduct->reloadData($mageProduct, $store); // Note the reload
                         $service->addProduct($nostoProduct);
                     }
                     $service->upsert();

--- a/app/code/community/Nosto/Tagging/Model/Service/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Service/Product.php
@@ -114,7 +114,7 @@ class Nosto_Tagging_Model_Service_Product
                         if (Mage::app()->getStore() === Mage_Core_Model_App::ADMIN_STORE_ID) {
                             $nostoProduct->reloadData($mageProduct, $store); // Note the reload
                         } else {
-                            $nostoProduct->load($mageProduct, $store);
+                            $nostoProduct->loadData($mageProduct, $store);
                         }
                         $service->addProduct($nostoProduct);
                     }

--- a/app/code/community/Nosto/Tagging/Model/Service/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Service/Product.php
@@ -102,14 +102,26 @@ class Nosto_Tagging_Model_Service_Product
             $emulation = Mage::getSingleton('core/app_emulation');
             $env = $emulation->startEnvironmentEmulation($store->getId());
             foreach ($productBatches as $productsInStore) {
-                $service = new NostoOperationProduct($account);
-                foreach ($productsInStore as $mageProduct) {
-                    /** @var Nosto_Tagging_Model_Meta_Product $nostoProduct */
-                    $nostoProduct = Mage::getModel('nosto_tagging/meta_product');
-                    $nostoProduct->loadData($mageProduct, $store);
-                    $service->addProduct($nostoProduct);
+                try {
+                    $service = new NostoOperationProduct($account);
+                    foreach ($productsInStore as $mageProduct) {
+                        /** @var Nosto_Tagging_Model_Meta_Product $nostoProduct */
+                        $nostoProduct = Mage::getModel('nosto_tagging/meta_product');
+                        // If the current store scope if the main store scope, also referred to as
+                        // the admin store scope, then we should reload the product as the store
+                        // code of the product refers to an pseudo store scope called "admin"
+                        // which leads to issues when flat tables are enabled.
+                        if (Mage::app()->getStore() === Mage_Core_Model_App::ADMIN_STORE_ID) {
+                            $nostoProduct->reloadData($mageProduct, $store); // Note the reload
+                        } else {
+                            $nostoProduct->load($mageProduct, $store);
+                        }
+                        $service->addProduct($nostoProduct);
+                    }
+                    $service->upsert();
+                } catch (Exception $e) {
+                    Mage::logException($e);
                 }
-                $service->upsert();
             }
             $emulation->stopEnvironmentEmulation($env);
         }

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Nosto_Tagging>
-            <version>2.11.1</version>
+            <version>2.11.2</version>
         </Nosto_Tagging>
     </modules>
     <global>

--- a/composer.lock
+++ b/composer.lock
@@ -230,16 +230,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.2.3",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7a8405a9fc175f87fed8a3c40856b0d866d61936"
+                "reference": "28fb243a2b5727774ca309ec2d92da240f1af0dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7a8405a9fc175f87fed8a3c40856b0d866d61936",
-                "reference": "7a8405a9fc175f87fed8a3c40856b0d866d61936",
+                "url": "https://api.github.com/repos/symfony/console/zipball/28fb243a2b5727774ca309ec2d92da240f1af0dd",
+                "reference": "28fb243a2b5727774ca309ec2d92da240f1af0dd",
                 "shasum": ""
             },
             "require": {
@@ -289,20 +289,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-06 12:04:21"
+            "time": "2017-03-06 19:30:27"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.2.3",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "b4d9818f127c60ce21ed62c395da7df868dc8477"
+                "reference": "b90c9f91ad8ac37d9f114e369042d3226b34dc1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/b4d9818f127c60ce21ed62c395da7df868dc8477",
-                "reference": "b4d9818f127c60ce21ed62c395da7df868dc8477",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/b90c9f91ad8ac37d9f114e369042d3226b34dc1a",
+                "reference": "b90c9f91ad8ac37d9f114e369042d3226b34dc1a",
                 "shasum": ""
             },
             "require": {
@@ -346,7 +346,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-28 02:37:08"
+            "time": "2017-02-18 17:28:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -409,16 +409,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.3",
+            "version": "v3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b"
+                "reference": "093e416ad096355149e265ea2e4cc1f9ee40ab1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e1718c6bf57e1efbb8793ada951584b2ab27775b",
-                "reference": "e1718c6bf57e1efbb8793ada951584b2ab27775b",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/093e416ad096355149e265ea2e4cc1f9ee40ab1a",
+                "reference": "093e416ad096355149e265ea2e4cc1f9ee40ab1a",
                 "shasum": ""
             },
             "require": {
@@ -460,7 +460,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21 17:06:35"
+            "time": "2017-03-07 16:47:02"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
When a product is updated for the main store scope i.e. "Default Values", that store has an identifier of `0` and is often referred to as the admin store scope. 

When flat tables are enabled in Magento, and you save a product for the admin store scope, the saving of grouped and bundled product often fails ad deep in the Magento core, there are references to the `$product->getStore()` and this value is used to determine whether or not to use flat tables. Since the value of that method points to a pseduo `admin` store scope in some cases, the product metadata loading fails.

This has now been addressed by reloading the product for the emulated store scope when the actual scope is `admin`. Closes #239 