### PR TITLE
Wrong JSON at product categories

### DIFF
--- a/app/code/community/Nosto/Tagging/Model/Meta/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Meta/Product.php
@@ -585,6 +585,9 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Tagging_Model_Base implemen
         /** @var Nosto_Tagging_Helper_Data $helper */
         $helper = Mage::helper('nosto_tagging');
         $categoryCollection = $product->getCategoryCollection();
+        
+        $categoryCollection->addAttributeToFilter('is_active', 1);
+        
         foreach ($categoryCollection as $category) {
             $categoryString = $helper->buildCategoryString($category);
             if (!empty($categoryString)) {
@@ -592,7 +595,7 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Tagging_Model_Base implemen
             }
         }
         
-        return array_unique($data);
+        return array_values(array_unique($data));
     }
 
     /**


### PR DESCRIPTION
There is a problem when building category strings for deactivated categories leading to wrong JSON. So deactivated categories can be excluded.

Additionally it is better to call array_values on $data to ensure that this array does not have any missing keys, which would lead to a JSON object instead of JSON array.