### PR TITLE
Fix saving simple product that has parent in a website without permission for the current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.7.6
+* Fix an issue in Magento Enterprise that would prevent to save a simple product if the logged user does not have permission to see the parent product.
+
 ### 3.7.5
 * Handle line items without concrete product in order confirmation
 * Fix price variation when customer group variation has zero price

--- a/app/code/community/Nosto/Tagging/Util/Product.php
+++ b/app/code/community/Nosto/Tagging/Util/Product.php
@@ -79,8 +79,9 @@ class Nosto_Tagging_Util_Product
                         $configurable = Mage::getModel('catalog/product')->load($productId);
                         $parents[] = $configurable;
                     } catch (\Exception $e) {
-                        Nosto_Tagging_Helper_Log::exception($e);
-                        continue;
+                        if ($e instanceof \Enterprise_AdminGws_Controller_Exception) {
+                            Nosto_Tagging_Helper_Log::exception($e);
+                        }
                     }
                 }
             }

--- a/app/code/community/Nosto/Tagging/Util/Product.php
+++ b/app/code/community/Nosto/Tagging/Util/Product.php
@@ -64,6 +64,8 @@ class Nosto_Tagging_Util_Product
      * product in array if no other parents were found.
      *
      * @param Mage_Catalog_Model_Product $product
+     * @suppress PhanUndeclaredClassInstanceof
+     * @suppress PhanTypeMismatchArgument
      * @return array
      */
     public static function toParentProducts(Mage_Catalog_Model_Product $product)

--- a/app/code/community/Nosto/Tagging/Util/Product.php
+++ b/app/code/community/Nosto/Tagging/Util/Product.php
@@ -75,8 +75,13 @@ class Nosto_Tagging_Util_Product
             $parentIds = $model->getParentIdsByChild($product->getId());
             if (!empty($parentIds)) {
                 foreach ($parentIds as $productId) {
-                    $configurable = Mage::getModel('catalog/product')->load($productId);
-                    $parents[] = $configurable;
+                    try {
+                        $configurable = Mage::getModel('catalog/product')->load($productId);
+                        $parents[] = $configurable;
+                    } catch (\Exception $e) {
+                        Nosto_Tagging_Helper_Log::exception($e);
+                        continue;
+                    }
                 }
             }
         }

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Nosto_Tagging>
-            <version>3.7.5</version>
+            <version>3.7.6</version>
         </Nosto_Tagging>
     </modules>
     <global>


### PR DESCRIPTION
Catch exception thrown by Magento enterprise when user has no access to parent product that’s in a different website.
Closes #444 