### PR TITLE
Handle duplicate key exception in Nosto customer saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.8.4
+* Handle duplicate key exception gracefully when saving Nosto customer
+
 ### 3.8.3
 * Bump Nosto SDK version to fix the double encoded Oauth redirect URL
 * Add null check to customer addresses

--- a/app/code/community/Nosto/Tagging/Helper/Customer.php
+++ b/app/code/community/Nosto/Tagging/Helper/Customer.php
@@ -89,12 +89,14 @@ class Nosto_Tagging_Helper_Customer extends Mage_Core_Helper_Abstract
                 $customer->setRestoreCartHash($restoreCartHash);
                 $customer->setCreatedAt($dateHelper->gmtDate());
             }
+            // @codingStandardsIgnoreStart
             try {
                 $customer->save();
             } catch (Zend_Db_Statement_Exception $e) {
                 // We don't need to care about the duplicate key exception
                 // that might happend occasionally due to concurrency
             }
+            // @codingStandardsIgnoreEnd
         }
     }
 

--- a/app/code/community/Nosto/Tagging/Helper/Customer.php
+++ b/app/code/community/Nosto/Tagging/Helper/Customer.php
@@ -89,14 +89,16 @@ class Nosto_Tagging_Helper_Customer extends Mage_Core_Helper_Abstract
                 $customer->setRestoreCartHash($restoreCartHash);
                 $customer->setCreatedAt($dateHelper->gmtDate());
             }
-            // @codingStandardsIgnoreStart
             try {
                 $customer->save();
             } catch (Zend_Db_Statement_Exception $e) {
-                // We don't need to care about the duplicate key exception
-                // that might happend occasionally due to concurrency
+                // Omit the duplicate key exception (code 23000)
+                // It happens occasionally especially with replicated
+                // database setup
+                if ($e->getCode() !== 23000) {
+                    throw $e;
+                }
             }
-            // @codingStandardsIgnoreEnd
         }
     }
 

--- a/app/code/community/Nosto/Tagging/Helper/Customer.php
+++ b/app/code/community/Nosto/Tagging/Helper/Customer.php
@@ -82,14 +82,18 @@ class Nosto_Tagging_Helper_Customer extends Mage_Core_Helper_Abstract
             /** @noinspection PhpUndefinedMethodInspection */
             if ($customer->hasData()) {
                 $customer->setUpdatedAt($dateHelper->gmtDate());
-                $customer->save();
             } else {
                 $restoreCartHash = $this->generateRestoreCartHash();
                 $customer->setQuoteId($quoteId);
                 $customer->setNostoId($nostoId);
                 $customer->setRestoreCartHash($restoreCartHash);
                 $customer->setCreatedAt($dateHelper->gmtDate());
+            }
+            try {
                 $customer->save();
+            } catch (Zend_Db_Statement_Exception $e) {
+                // We don't need to care about the duplicate key exception
+                // that might happend occasionally due to concurrency
             }
         }
     }

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Nosto_Tagging>
-            <version>3.8.3</version>
+            <version>3.8.4</version>
         </Nosto_Tagging>
     </modules>
     <global>


### PR DESCRIPTION
closes #486

## Description
Catch duplicate key exception when saving Nosto customer.

## Related Issue
#486 

## Motivation and Context
This causes redundant error reporting for merchants and this can happen often with replicated db setups. 

## How Has This Been Tested?
Tested locally 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers