### PR TITLE
Hotfix/3.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.8.5
+* Handle overriding custom group pricing 
+
 ### 3.8.4
 * Handle duplicate key exception gracefully when saving Nosto customer
 

--- a/app/code/community/Nosto/Tagging/Model/Meta/Product/Trait.php
+++ b/app/code/community/Nosto/Tagging/Model/Meta/Product/Trait.php
@@ -113,15 +113,18 @@ trait Nosto_Tagging_Model_Meta_Product_Trait
     {
         /** @var Nosto_Tagging_Helper_Price $priceHelper */
         $priceHelper = Mage::helper('nosto_tagging/price');
+        $productClone = $product;
 
         /** @var Nosto_Tagging_Helper_Data $dataHelper */
         $dataHelper = Mage::helper('nosto_tagging/data');
         if ($dataHelper->isVariationEnabled($store)) {
             // We need to set the default customer group here, otherwise Magento will
             // return the price for the current user logged in group.
-            $product->setGroupPrice(Nosto_Tagging_Helper_Variation::DEFAULT_CUSTOMER_GROUP_ID);
+            $productClone = clone $product;
+            $productClone->setGroupPrice(Nosto_Tagging_Helper_Variation::DEFAULT_CUSTOMER_GROUP_ID);
         }
-        return $priceHelper->getProductTaggingPrice($product, $store, true);
+
+        return $priceHelper->getProductTaggingPrice($productClone, $store, true);
     }
 
     /**

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Nosto_Tagging>
-            <version>3.8.4</version>
+            <version>3.8.5</version>
         </Nosto_Tagging>
     </modules>
     <global>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Stop using magento product object in buildProductPrice() method in  Product/Trait.php, but instead clone it to a new object and set group prices to this new object.  

## Related Issue
closes #490

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Merchant encountered a bug while enabling customGroup pricing. When nosto module was enabled, the price being displayed was the default one, not the group one. This was caused due to overriding Magento's object price grouping. 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers