### PR TITLE
Feature - Indexer Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.9.0 (Unreleased)
+* Adds a feature flag to set the a percentage of total PHP available memory that can be used by Nosto indexer;
+
 ### 3.8.5
 * Handle overriding custom group pricing 
 

--- a/app/code/community/Nosto/Tagging/Helper/Data.php
+++ b/app/code/community/Nosto/Tagging/Helper/Data.php
@@ -123,6 +123,11 @@ class Nosto_Tagging_Helper_Data extends Mage_Core_Helper_Abstract
     const XML_PATH_RESTORE_CART_LOCATION = 'nosto_tagging/general/restore_cart_location';
 
     /**
+     * Path to store config for indexer allowed memory percentage
+     */
+    const XML_PATH_INDEXER_MEMORY = 'nosto_tagging/general/indexer_memory';
+
+    /**
      * Path to store config for custom fields
      */
     const XML_PATH_USE_CUSTOM_FIELDS = 'nosto_tagging/general/use_custom_fields';
@@ -695,6 +700,18 @@ class Nosto_Tagging_Helper_Data extends Mage_Core_Helper_Abstract
     public function getRestoreCartRedirectLocation($store = null)
     {
         return Mage::getStoreConfig(self::XML_PATH_RESTORE_CART_LOCATION, $store);
+    }
+
+    /**
+     * Return the percentage of allowed memory for the indexer
+     *
+     * @param Mage_Core_Model_Store|null $store the store model or null.
+     *
+     * @return string
+     */
+    public function getIndexerMemoryPercentage($store = null)
+    {
+        return Mage::getStoreConfig(self::XML_PATH_INDEXER_MEMORY, $store);
     }
 
     /**

--- a/app/code/community/Nosto/Tagging/Helper/Log.php
+++ b/app/code/community/Nosto/Tagging/Helper/Log.php
@@ -89,6 +89,25 @@ class Nosto_Tagging_Helper_Log extends Mage_Core_Helper_Abstract
     }
 
     /**
+     * Logs a message along with the memory consumption
+     *
+     * @param $message
+     * @return bool
+     */
+    public function logWithMemoryConsumption($message)
+    {
+        return self::info(
+            sprintf(
+                '%s [mem usage: %sM / %s] [realmem: %sM]',
+                $message,
+                Nosto_Util_Memory::getConsumption(),
+                Nosto_Util_Memory::getTotalMemoryLimit(),
+                Nosto_Util_Memory::getRealConsumption()
+            )
+        );
+    }
+
+    /**
      * Writes warning into the log
      *
      * @param string $message

--- a/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
@@ -445,7 +445,8 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
      * Wrapper that invalidates indexer status
      * @return void
      */
-    protected function invalidateIndexerStatus() {
+    protected function invalidateIndexerStatus()
+    {
         /** @var Mage_Index_Model_Indexer $indexerModel */
         $indexerModel = Mage::getSingleton('index/indexer');
         $indexerModel

--- a/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
@@ -391,7 +391,6 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
                         $maxMemPercentage
                     )
                 );
-                $this->invalidateIndexerStatus();
                 return;
             }
 
@@ -439,19 +438,6 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
                 $changed
             )
         );
-    }
-
-    /**
-     * Wrapper that invalidates indexer status
-     * @return void
-     */
-    protected function invalidateIndexerStatus()
-    {
-        /** @var Mage_Index_Model_Indexer $indexerModel */
-        $indexerModel = Mage::getSingleton('index/indexer');
-        $indexerModel
-            ->getProcessByCode('nosto_indexer')
-            ->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
     }
 
     /**

--- a/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
@@ -387,10 +387,11 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
             if (Nosto_Util_Memory::getPercentageUsedMem() >= $maxMemPercentage) {
                 Nosto_Tagging_Helper_Log::info(
                     sprintf(
-                        'Memory used by indexer is over %d%% allowed',
+                        'Memory used by indexer is over %d%% allowed, finishing...',
                         $maxMemPercentage
                     )
                 );
+                $this->invalidateIndexerStatus();
                 return;
             }
 
@@ -438,6 +439,18 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
                 $changed
             )
         );
+    }
+
+    /**
+     * Wrapper that invalidates indexer status
+     * @return void
+     */
+    protected function invalidateIndexerStatus() {
+        /** @var Mage_Index_Model_Indexer $indexerModel */
+        $indexerModel = Mage::getSingleton('index/indexer');
+        $indexerModel
+            ->getProcessByCode('nosto_indexer')
+            ->changeStatus(Mage_Index_Model_Process::STATUS_REQUIRE_REINDEX);
     }
 
     /**

--- a/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
@@ -553,6 +553,7 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
 
     /**
      * Reindex all products in all stores where Nosto is installed
+     * @throws Nosto_Exception_MemoryOutOfBoundsException
      */
     public function reindexAll()
     {
@@ -567,7 +568,7 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
                     $this->reindexAllInStore($store);
                 } catch (Nosto_Exception_MemoryOutOfBoundsException $e) {
                     Nosto_Tagging_Helper_Log::info($e->getMessage());
-                    throw new Mage_Core_Exception($e);
+                    throw $e;
                 } catch (\Exception $e) {
                     NostoLog::exception($e);
                 }

--- a/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Indexer/Product.php
@@ -62,7 +62,7 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
     protected $_deleteQueue = array();
 
     /**
-     * Array containing already procecced product ids
+     * Array containing already processed product ids
      *
      * @var array
      */
@@ -82,8 +82,6 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
      * @var int
      */
     public static $maxBatchCount = 10000;
-
-
 
     /**
      * Matched Entities instruction array
@@ -301,8 +299,8 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
             foreach ($products as $product) {
                 /* @var Nosto_Tagging_Model_Meta_Product $nostoProduct */
                 $nostoProduct = Mage::getModel('nosto_tagging/meta_product');
-                if ($nostoProduct->reloadData($product, $store)
-                    && $nostoProduct instanceof Nosto_Tagging_Model_Meta_Product
+                if ($nostoProduct instanceof Nosto_Tagging_Model_Meta_Product
+                    && $nostoProduct->reloadData($product, $store)
                 ) {
                     $this->reindexProductInStore($nostoProduct, $store);
                 }
@@ -355,7 +353,7 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
      */
     protected function _processEvent(Mage_Index_Model_Event $event)
     {
-        if ($event->getType() == 'delete') {
+        if ($event->getType() === 'delete') {
             $this->flushDeleteQueue();
         } else {
             $this->flushReindexingQueue();
@@ -394,7 +392,7 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
                 break;
             }
             $batchCount = count($products);
-            if ($batchCount == 0) {
+            if ($batchCount === 0) {
                 break;
             }
             Nosto_Tagging_Helper_Log::info(
@@ -496,9 +494,9 @@ class Nosto_Tagging_Model_Indexer_Product extends Mage_Index_Model_Indexer_Abstr
         if ($indexedProduct instanceof Nosto_Tagging_Model_Index) {
             $indexedMetaProduct = $indexedProduct->getNostoMetaProduct();
 
-            if ($indexedMetaProduct instanceof Nosto_Tagging_Model_Meta_Product === false
+            if (!$indexedMetaProduct instanceof Nosto_Tagging_Model_Meta_Product
+                || $indexedMetaProduct !== $nostoProduct
                 || $this->isExpired($indexedProduct)
-                || $indexedMetaProduct != $nostoProduct
             ) {
                 $indexedProduct->setNostoMetaProduct($nostoProduct);
                 $indexedProduct->setUpdatedAt($dateHelper->gmtDate());

--- a/app/code/community/Nosto/Tagging/Model/Service/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Service/Product.php
@@ -32,7 +32,7 @@
 class Nosto_Tagging_Model_Service_Product
 {
     /**
-     * Maximum batch size. If exceeded the batches will be splitted into smaller
+     * Maximum batch size. If exceeded, the batches will be splitted into smaller
      * ones.
      *
      * @var int
@@ -182,8 +182,7 @@ class Nosto_Tagging_Model_Service_Product
             $account = $helper->find($store);
             /* @var $nostoHelper Nosto_Tagging_Helper_Data */
             $nostoHelper = Mage::helper('nosto_tagging');
-            if (
-                $account === null
+            if ($account === null
                 || !$account->isConnectedToNosto()
                 || !$nostoHelper->getUseProductApi($store)
             ) {
@@ -207,10 +206,10 @@ class Nosto_Tagging_Model_Service_Product
                 $operation = new Nosto_Operation_UpsertProduct($account);
                 $operation->setResponseTimeout($this->getApiWaitTimeout());
                 $batchCount = count($indexedProducts);
-                if ($batchCount == 0) {
+                if ($batchCount === 0) {
                     break;
                 }
-                Nosto_Tagging_Helper_Log::info(
+                Nosto_Tagging_Helper_Log::logWithMemoryConsumption(
                     sprintf(
                         'Synchronizing %d products in store %s to Nosto [%d/%d]',
                         $batchCount,
@@ -243,7 +242,7 @@ class Nosto_Tagging_Model_Service_Product
                 $indexedProducts = $this->getOutOfSyncBatch($store);
             }
 
-            Nosto_Tagging_Helper_Log::info(
+            Nosto_Tagging_Helper_Log::logWithMemoryConsumption(
                 sprintf(
                     'Synchronizing for store %s done in %d secs',
                     $store->getCode(),
@@ -257,9 +256,7 @@ class Nosto_Tagging_Model_Service_Product
      * @param Mage_Core_Model_Store $store
      * @return mixed
      */
-    protected function getOutOfSyncBatch(
-        Mage_Core_Model_Store $store
-    ) 
+    protected function getOutOfSyncBatch(Mage_Core_Model_Store $store)
     {
         return Mage::getModel('nosto_tagging/index')
             ->getCollection()

--- a/app/code/community/Nosto/Tagging/Model/System/Config/Source/Memory/Percentage.php
+++ b/app/code/community/Nosto/Tagging/Model/System/Config/Source/Memory/Percentage.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category  Nosto
+ * @package   Nosto_Tagging
+ * @author    Nosto Solutions Ltd <magento@nosto.com>
+ * @copyright Copyright (c) 2013-2017 Nosto Solutions Ltd (http://www.nosto.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Source Model that adds dropdown with memory percentage in steps of 10%
+ *
+ * @category Nosto
+ * @package  Nosto_Tagging
+ * @author   Nosto Solutions Ltd <magento@nosto.com>
+ * @suppress PhanUnreferencedClass
+ */
+class Nosto_Tagging_Model_System_Config_Source_Memory_Percentage
+{
+    /**
+     * Returns percentages of memory in steps of 10%
+     *
+     * @return array the options.
+     */
+    public function toOptionArray()
+    {
+        $options = array();
+        for ($i = 10; $i <= 100; $i += 10) {
+            $options[] = array(
+                'value' => $i,
+                'label' => $i . '%'
+            );
+        }
+        return $options;
+    }
+}

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -279,6 +279,7 @@
                 <update_catalog_price_rules>0</update_catalog_price_rules>
                 <send_customer_data>1</send_customer_data>
                 <restore_cart_location>checkout/cart</restore_cart_location>
+                <indexer_memory>50</indexer_memory>
             </general>
             <image_options>
                 <image_version>image</image_version>

--- a/app/code/community/Nosto/Tagging/etc/system.xml
+++ b/app/code/community/Nosto/Tagging/etc/system.xml
@@ -198,6 +198,18 @@
                             <show_in_store>1</show_in_store>
                         </restore_cart_location>
                     </fields>
+                    <fields>
+                        <indexer_memory translate="label">
+                            <label>Indexer Memory</label>
+                            <comment>Percentage of total PHP available memory that Nosto indexer is allowed to use</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>nosto_tagging/system_config_source_memory_percentage</source_model>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </indexer_memory>
+                    </fields>
                 </general>
                 <currency_formats translate="label">
                     <label>Currency formats</label>

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
                     "reference": "origin/magento-1.9"
                 }
             }
+        },
+        "pearify": {
+            "type": "vcs",
+            "url": "https://github.com/supercid/pearify"
         }
     },
     "require": {
@@ -37,7 +41,7 @@
         "magento/marketplace-eqp": "1.*",
         "openmage/magento-mirror": "1.9",
         "wimg/php-compatibility": "^8.0",
-        "mridang/pearify": "0.2"
+        "mridang/pearify": "dev-hotfix/support-traits"
     },
     "scripts": {
         "post-install-cmd": "if ! type \"composer\" > /dev/null; then echo \"composer not available in path - you must update the lib files manually\"; else composer dump-autoload --optimize; ./vendor/bin/pearify process .;fi",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "nosto/php-sdk": "3.9.1"
+        "nosto/php-sdk": "dev-develop"
     },
     "require-dev": {
         "php": ">=7.1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,11 @@
                     "reference": "origin/magento-1.9"
                 }
             }
-        },
-        "pearify": {
-            "type": "vcs",
-            "url": "https://github.com/supercid/pearify"
         }
     },
     "require": {
         "php": ">=5.4.0",
-        "nosto/php-sdk": "dev-develop"
+        "nosto/php-sdk": "3.11.0"
     },
     "require-dev": {
         "php": ">=7.1.0",
@@ -41,7 +37,7 @@
         "magento/marketplace-eqp": "1.*",
         "openmage/magento-mirror": "1.9",
         "wimg/php-compatibility": "^8.0",
-        "mridang/pearify": "dev-hotfix/support-traits"
+        "mridang/pearify": "0.3"
     },
     "scripts": {
         "post-install-cmd": "if ! type \"composer\" > /dev/null; then echo \"composer not available in path - you must update the lib files manually\"; else composer dump-autoload --optimize; ./vendor/bin/pearify process .;fi",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb76e66beb4d918ee3653e0af51bbeef",
+    "content-hash": "17ad355ba8b0c892a17d5420a1317253",
     "packages": [
         {
             "name": "nosto/php-sdk",
-            "version": "dev-develop",
+            "version": "3.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "e28e65dde0cf628558b9f660aaa3453a1b3cafd4"
+                "reference": "e193335c1b2d8cca05eae9ddf1efccb44e56ca8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/e28e65dde0cf628558b9f660aaa3453a1b3cafd4",
-                "reference": "e28e65dde0cf628558b9f660aaa3453a1b3cafd4",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/e193335c1b2d8cca05eae9ddf1efccb44e56ca8e",
+                "reference": "e193335c1b2d8cca05eae9ddf1efccb44e56ca8e",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
                 "BSD-3-Clause"
             ],
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
-            "time": "2019-02-28T10:53:55+00:00"
+            "time": "2019-03-05T14:36:39+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -352,16 +352,16 @@
         },
         {
             "name": "mridang/pearify",
-            "version": "dev-hotfix/support-traits",
+            "version": "0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/supercid/pearify.git",
-                "reference": "c459d15e45289b6611de39d68e203b29eb23df05"
+                "url": "https://github.com/mridang/pearify.git",
+                "reference": "7bc0710beb4165164e07f88b456de47cad8b3002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/supercid/pearify/zipball/c459d15e45289b6611de39d68e203b29eb23df05",
-                "reference": "c459d15e45289b6611de39d68e203b29eb23df05",
+                "url": "https://api.github.com/repos/mridang/pearify/zipball/7bc0710beb4165164e07f88b456de47cad8b3002",
+                "reference": "7bc0710beb4165164e07f88b456de47cad8b3002",
                 "shasum": ""
             },
             "require": {
@@ -376,6 +376,7 @@
                     "Pearify\\": "src/Pearify"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -388,16 +389,12 @@
             "description": "Pearify converts PSR-4 Composer packages to PEAR compliant code.",
             "homepage": "https://github.com/mridang/pearify",
             "keywords": [
+                "PEAR",
+                "PSR-4",
                 "magento",
-                "package",
-                "pear",
-                "psr-4"
+                "package"
             ],
-            "support": {
-                "issues": "https://github.com/mridang/pearify/issues",
-                "source": "https://github.com/supercid/pearify/tree/hotfix/support-traits"
-            },
-            "time": "2019-03-08T08:56:40+00:00"
+            "time": "2019-03-11T09:48:50+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -2074,10 +2071,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "nosto/php-sdk": 20,
-        "mridang/pearify": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,24 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "c3ac7ffe83b971b272c061af8dcadbb9",
-    "content-hash": "813f0bbea8462f010f698e91ac8176b1",
+    "content-hash": "521cb11c6375aad59e6551c55fca12d5",
     "packages": [
         {
             "name": "nosto/php-sdk",
-            "version": "3.9.1",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "3f23e96088c66210806c1b3447d19c3cb22bacd3"
+                "reference": "e28e65dde0cf628558b9f660aaa3453a1b3cafd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/3f23e96088c66210806c1b3447d19c3cb22bacd3",
-                "reference": "3f23e96088c66210806c1b3447d19c3cb22bacd3",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/e28e65dde0cf628558b9f660aaa3453a1b3cafd4",
+                "reference": "e28e65dde0cf628558b9f660aaa3453a1b3cafd4",
                 "shasum": ""
             },
             "require": {
@@ -52,7 +51,7 @@
                 "BSD-3-Clause"
             ],
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
-            "time": "2019-01-23 14:02:35"
+            "time": "2019-02-28T10:53:55+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -144,7 +143,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2019-01-27 19:37:29"
+            "time": "2019-01-27T19:37:29+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -194,7 +193,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2018-10-30 17:29:25"
+            "time": "2018-10-30T17:29:25+00:00"
         }
     ],
     "packages-dev": [
@@ -237,7 +236,7 @@
                 }
             ],
             "description": "A more advanced JSONRPC implementation",
-            "time": "2017-06-22 12:18:44"
+            "time": "2017-06-22T12:18:44+00:00"
         },
         {
             "name": "magento-ecg/coding-standard",
@@ -270,7 +269,7 @@
             ],
             "description": "A set of PHP_CodeSniffer rules and sniffs.",
             "homepage": "https://github.com/magento-ecg/coding-standard",
-            "time": "2017-05-18 19:12:29"
+            "time": "2017-05-18T19:12:29+00:00"
         },
         {
             "name": "magento/marketplace-eqp",
@@ -299,7 +298,7 @@
                 "source": "https://github.com/magento/marketplace-eqp/tree/1.0.3",
                 "issues": "https://github.com/magento/marketplace-eqp/issues"
             },
-            "time": "2016-09-29 15:14:39"
+            "time": "2016-09-29T15:14:39+00:00"
         },
         {
             "name": "mridang/magazine",
@@ -349,7 +348,7 @@
                 "magento",
                 "package"
             ],
-            "time": "2016-10-07 08:04:43"
+            "time": "2016-10-07T08:04:43+00:00"
         },
         {
             "name": "mridang/pearify",
@@ -395,7 +394,7 @@
                 "magento",
                 "package"
             ],
-            "time": "2017-05-02 06:36:20"
+            "time": "2017-05-02T06:36:20+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -437,7 +436,7 @@
                 }
             ],
             "description": "Map nested JSON structures onto PHP classes",
-            "time": "2017-11-28 21:30:01"
+            "time": "2017-11-28T21:30:01+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -488,7 +487,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-02-28 20:30:58"
+            "time": "2018-02-28T20:30:58+00:00"
         },
         {
             "name": "openmage/magento-mirror",
@@ -538,7 +537,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2017-12-13 13:21:38"
+            "time": "2017-12-13T13:21:38+00:00"
         },
         {
             "name": "phan/phan",
@@ -597,7 +596,7 @@
                 "php",
                 "static"
             ],
-            "time": "2017-10-21 02:26:51"
+            "time": "2017-10-21T02:26:51+00:00"
         },
         {
             "name": "phing/phing",
@@ -690,7 +689,7 @@
                 "task",
                 "tool"
             ],
-            "time": "2018-01-25 13:18:09"
+            "time": "2018-01-25T13:18:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -744,7 +743,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11 18:02:19"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -789,7 +788,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10 14:09:06"
+            "time": "2017-11-10T14:09:06+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -836,7 +835,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14 14:27:02"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -902,7 +901,7 @@
                 "phpmd",
                 "pmd"
             ],
-            "time": "2017-01-20 14:41:10"
+            "time": "2017-01-20T14:41:10+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -951,7 +950,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2018-02-01 13:07:23"
+            "time": "2018-02-01T13:07:23+00:00"
         },
         {
             "name": "psr/container",
@@ -1000,7 +999,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14 16:28:37"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/log",
@@ -1047,7 +1046,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20 15:27:04"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "sabre/event",
@@ -1107,7 +1106,7 @@
                 "reactor",
                 "signal"
             ],
-            "time": "2018-03-05 13:55:47"
+            "time": "2018-03-05T13:55:47+00:00"
         },
         {
             "name": "sebastian/finder-facade",
@@ -1146,7 +1145,7 @@
             ],
             "description": "FinderFacade is a convenience wrapper for Symfony's Finder component.",
             "homepage": "https://github.com/sebastianbergmann/finder-facade",
-            "time": "2017-11-18 17:31:49"
+            "time": "2017-11-18T17:31:49+00:00"
         },
         {
             "name": "sebastian/phpcpd",
@@ -1197,7 +1196,7 @@
             ],
             "description": "Copy/Paste Detector (CPD) for PHP code.",
             "homepage": "https://github.com/sebastianbergmann/phpcpd",
-            "time": "2018-09-17 17:17:27"
+            "time": "2018-09-17T17:17:27+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1240,7 +1239,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1318,7 +1317,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-05-30 22:24:32"
+            "time": "2016-05-30T22:24:32+00:00"
         },
         {
             "name": "symfony/config",
@@ -1381,7 +1380,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-03 09:07:35"
+            "time": "2019-01-03T09:07:35+00:00"
         },
         {
             "name": "symfony/console",
@@ -1450,7 +1449,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-04 04:42:43"
+            "time": "2019-01-04T04:42:43+00:00"
         },
         {
             "name": "symfony/contracts",
@@ -1518,7 +1517,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2018-12-05 08:06:11"
+            "time": "2018-12-05T08:06:11+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1574,7 +1573,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-03 09:07:35"
+            "time": "2019-01-03T09:07:35+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -1647,7 +1646,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-05 16:37:49"
+            "time": "2019-01-05T16:37:49+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1697,7 +1696,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-03 09:07:35"
+            "time": "2019-01-03T09:07:35+00:00"
         },
         {
             "name": "symfony/finder",
@@ -1746,7 +1745,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-03 09:07:35"
+            "time": "2019-01-03T09:07:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1804,7 +1803,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06 14:22:27"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1863,7 +1862,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21 13:07:52"
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1922,7 +1921,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-03 09:07:35"
+            "time": "2019-01-03T09:07:35+00:00"
         },
         {
             "name": "theseer/fdomdocument",
@@ -1962,7 +1961,7 @@
             ],
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
-            "time": "2017-06-30 11:53:12"
+            "time": "2017-06-30T11:53:12+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2013,7 +2012,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25 11:19:39"
+            "time": "2018-12-25T11:19:39+00:00"
         },
         {
             "name": "wimg/php-compatibility",
@@ -2067,16 +2066,20 @@
                 "standards"
             ],
             "abandoned": "phpcompatibility/php-compatibility",
-            "time": "2018-07-17 13:42:26"
+            "time": "2018-07-17T13:42:26+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "nosto/php-sdk": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.4.0"
     },
-    "platform-dev": []
+    "platform-dev": {
+        "php": ">=7.1.0"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "521cb11c6375aad59e6551c55fca12d5",
+    "content-hash": "eb76e66beb4d918ee3653e0af51bbeef",
     "packages": [
         {
             "name": "nosto/php-sdk",
@@ -352,16 +352,16 @@
         },
         {
             "name": "mridang/pearify",
-            "version": "0.2",
+            "version": "dev-hotfix/support-traits",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mridang/pearify.git",
-                "reference": "958ba3fad442c82e681eeff9b906aa4f0d87452f"
+                "url": "https://github.com/supercid/pearify.git",
+                "reference": "c459d15e45289b6611de39d68e203b29eb23df05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mridang/pearify/zipball/958ba3fad442c82e681eeff9b906aa4f0d87452f",
-                "reference": "958ba3fad442c82e681eeff9b906aa4f0d87452f",
+                "url": "https://api.github.com/repos/supercid/pearify/zipball/c459d15e45289b6611de39d68e203b29eb23df05",
+                "reference": "c459d15e45289b6611de39d68e203b29eb23df05",
                 "shasum": ""
             },
             "require": {
@@ -376,7 +376,6 @@
                     "Pearify\\": "src/Pearify"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -389,12 +388,16 @@
             "description": "Pearify converts PSR-4 Composer packages to PEAR compliant code.",
             "homepage": "https://github.com/mridang/pearify",
             "keywords": [
-                "PEAR",
-                "PSR-4",
                 "magento",
-                "package"
+                "package",
+                "pear",
+                "psr-4"
             ],
-            "time": "2017-05-02T06:36:20+00:00"
+            "support": {
+                "issues": "https://github.com/mridang/pearify/issues",
+                "source": "https://github.com/supercid/pearify/tree/hotfix/support-traits"
+            },
+            "time": "2019-03-08T08:56:40+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -1792,7 +1795,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -2072,7 +2075,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "nosto/php-sdk": 20
+        "nosto/php-sdk": 20,
+        "mridang/pearify": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
- Adds memory logging to the indexer;
- Adds a feature flag to set the a percentage of total PHP available memory that can be used by Nosto indexer;
- Exit indexer gracefully if the memory consumption goes over the predefined amount.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #499
Mentions #474
Mentions #485

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It has been reported that the indexer process can cause Out-Of-Memory erros with a large catalog. This PR intends to fix this issue by quitting our indexer before killing the whole PHP process, which allows other indexers that run after Nosto Indexer to complete.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Magento 1.9.4 CE

You can use the following command to limit the amount of memory given to the indexer by PHP
`php -dmemory_limit=350M ./shell/indexer.php --reindex nosto_indexer`

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

- [x] Add feature flag documentation here: https://github.com/Nosto/nosto-magento/wiki/Configuring
--> https://github.com/Nosto/nosto-magento/wiki/Configuring#indexer-memory
- [x] Describe the flag also here: https://github.com/Nosto/nosto-magento/wiki/Indexer
--> https://github.com/Nosto/nosto-magento/wiki/Indexer#limiting-available-memory-for-the-indexer

## Drawbacks:
- Magento does not know about `Nosto_Exception`, therefore will throw an error such as:
`Nosto Products index process unknown error:
Nosto_Exception_MemoryOutOfBoundsException: Memory Out Of Bounds Error: Memory used by indexer is over 50% allowed in [...]`.
This could be fixed throwing `Mage_Core_Exception`, but this is misleading since it's not a Magento core exception.

- The indexer will throw a fatal error and this will subsequently stop any other indexer running after Nosto during the reindex all command
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers