### PR TITLE
Feature - Bump SDK and add date published to product tagging

### DIFF
--- a/app/code/community/Nosto/Tagging/Helper/Data.php
+++ b/app/code/community/Nosto/Tagging/Helper/Data.php
@@ -113,6 +113,11 @@ class Nosto_Tagging_Helper_Data extends Mage_Core_Helper_Abstract
     const XML_PATH_SEND_CUSTOMER_DATA = 'nosto_tagging/general/send_customer_data';
 
     /**
+     * Path to store config for tagging the date a product has beed added to Magento's catalog
+     */
+    const XML_PATH_TAG_DATE_PUBLISHED = 'nosto_tagging/general/tag_date_published';
+
+    /**
      * Path to store config for using SKUs
      */
     const XML_PATH_USE_SKUS = 'nosto_tagging/general/use_skus';
@@ -567,6 +572,17 @@ class Nosto_Tagging_Helper_Data extends Mage_Core_Helper_Abstract
     public function getUseSkus($store = null)
     {
         return (bool)Mage::getStoreConfig(self::XML_PATH_USE_SKUS, $store);
+    }
+
+    /**
+     * Returns on/off setting for tagging product's date published
+     *
+     * @param Mage_Core_Model_Store|null $store the store model or null.
+     * @return boolean
+     */
+    public function getTagDatePublished($store = null)
+    {
+        return (bool)Mage::getStoreConfig(self::XML_PATH_TAG_DATE_PUBLISHED, $store);
     }
 
     /**

--- a/app/code/community/Nosto/Tagging/Model/Meta/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Meta/Product.php
@@ -142,7 +142,11 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Object_Product_Product
             $this->setCustomFields($this->buildCustomFields($product, $store));
         }
         if ($dataHelper->getTagDatePublished($store) && $product->hasData('created_at')) {
-            $this->setDatePublished($product->getData('created_at'));
+            try {
+                $this->setDatePublished($product->getData('created_at'));
+            } catch (Nosto_NostoException $e) {
+                Nosto_Tagging_Helper_Log::exception($e);
+            }
         }
 
         Mage::dispatchEvent(

--- a/app/code/community/Nosto/Tagging/Model/Meta/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Meta/Product.php
@@ -141,7 +141,7 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Object_Product_Product
         if ($dataHelper->getUseCustomFields($store)) {
             $this->setCustomFields($this->buildCustomFields($product, $store));
         }
-        if ($product->hasData('created_at')) {
+        if ($dataHelper->getTagDatePublished($store) && $product->hasData('created_at')) {
             $this->setDatePublished($product->getData('created_at'));
         }
 

--- a/app/code/community/Nosto/Tagging/Model/Meta/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Meta/Product.php
@@ -141,6 +141,9 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Object_Product_Product
         if ($dataHelper->getUseCustomFields($store)) {
             $this->setCustomFields($this->buildCustomFields($product, $store));
         }
+        if ($product->hasData('created_at')) {
+            $this->setDatePublished($product->getData('created_at'));
+        }
 
         Mage::dispatchEvent(
             Nosto_Tagging_Helper_Event::EVENT_NOSTO_PRODUCT_LOAD_AFTER,

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -275,6 +275,7 @@
                 <send_inventory_level_after_purchase>0</send_inventory_level_after_purchase>
                 <use_low_stock>0</use_low_stock>
                 <personalized_category_sorting>1</personalized_category_sorting>
+                <tag_date_published>0</tag_date_published>
                 <update_catalog_price_rules>0</update_catalog_price_rules>
                 <send_customer_data>1</send_customer_data>
                 <restore_cart_location>checkout/cart</restore_cart_location>

--- a/app/code/community/Nosto/Tagging/etc/system.xml
+++ b/app/code/community/Nosto/Tagging/etc/system.xml
@@ -176,7 +176,7 @@
                     </fields>
                     <fields>
                         <tag_date_published translate="label">
-                            <label>Add date published date to product tagging</label>
+                            <label>Add product published date to tagging</label>
                             <comment>Set this yes if you want to tag the date a product has been added to Magento's catalog</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>

--- a/app/code/community/Nosto/Tagging/etc/system.xml
+++ b/app/code/community/Nosto/Tagging/etc/system.xml
@@ -175,6 +175,18 @@
                         </personalized_category_sorting>
                     </fields>
                     <fields>
+                        <tag_date_published translate="label">
+                            <label>Add date published date to product tagging</label>
+                            <comment>Set this yes if you want to tag the date a product has been added to Magento's catalog</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>80</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </tag_date_published>
+                    </fields>
+                    <fields>
                         <restore_cart_location translate="label">
                             <label>Redirect location after cart restore</label>
                             <comment>Choose where the visitor will be redirected after the cart has been restored</comment>

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "nosto/php-sdk": "3.12.1"
+        "nosto/php-sdk": "3.13.0"
     },
     "require-dev": {
         "php": ">=7.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,24 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "cc600b41af90688485cf7442824e4a86",
-    "content-hash": "cca3147e1985e72fd1159b4c73fa8d30",
+    "content-hash": "8567516866ecf1cd4087dbc8b6b76dba",
     "packages": [
         {
             "name": "nosto/php-sdk",
-            "version": "3.12.1",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nosto/nosto-php-sdk.git",
-                "reference": "4ab720d3fb1cb95a8edfb9c4a303f8957601beb5"
+                "reference": "980fdeeab0583cae842cffc04552842edb33e046"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/4ab720d3fb1cb95a8edfb9c4a303f8957601beb5",
-                "reference": "4ab720d3fb1cb95a8edfb9c4a303f8957601beb5",
+                "url": "https://api.github.com/repos/Nosto/nosto-php-sdk/zipball/980fdeeab0583cae842cffc04552842edb33e046",
+                "reference": "980fdeeab0583cae842cffc04552842edb33e046",
                 "shasum": ""
             },
             "require": {
@@ -52,7 +51,7 @@
                 "BSD-3-Clause"
             ],
             "description": "PHP SDK for developing Nosto modules for e-commerce platforms",
-            "time": "2019-03-28 08:25:44"
+            "time": "2019-04-08T13:02:49+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -144,7 +143,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2019-01-27 19:37:29"
+            "time": "2019-01-27T19:37:29+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -202,7 +201,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06 07:57:58"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -253,7 +252,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2019-01-28 20:57:27"
+            "time": "2019-01-28T20:57:27+00:00"
         }
     ],
     "packages-dev": [
@@ -296,7 +295,7 @@
                 }
             ],
             "description": "A more advanced JSONRPC implementation",
-            "time": "2017-06-22 12:18:44"
+            "time": "2017-06-22T12:18:44+00:00"
         },
         {
             "name": "magento-ecg/coding-standard",
@@ -329,7 +328,7 @@
             ],
             "description": "A set of PHP_CodeSniffer rules and sniffs.",
             "homepage": "https://github.com/magento-ecg/coding-standard",
-            "time": "2017-05-18 19:12:29"
+            "time": "2017-05-18T19:12:29+00:00"
         },
         {
             "name": "magento/marketplace-eqp",
@@ -358,7 +357,7 @@
                 "source": "https://github.com/magento/marketplace-eqp/tree/1.0.3",
                 "issues": "https://github.com/magento/marketplace-eqp/issues"
             },
-            "time": "2016-09-29 15:14:39"
+            "time": "2016-09-29T15:14:39+00:00"
         },
         {
             "name": "mridang/magazine",
@@ -408,7 +407,7 @@
                 "magento",
                 "package"
             ],
-            "time": "2016-10-07 08:04:43"
+            "time": "2016-10-07T08:04:43+00:00"
         },
         {
             "name": "mridang/pearify",
@@ -454,7 +453,7 @@
                 "magento",
                 "package"
             ],
-            "time": "2019-03-11 09:48:50"
+            "time": "2019-03-11T09:48:50+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -496,7 +495,7 @@
                 }
             ],
             "description": "Map nested JSON structures onto PHP classes",
-            "time": "2017-11-28 21:30:01"
+            "time": "2017-11-28T21:30:01+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -547,7 +546,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-02-28 20:30:58"
+            "time": "2018-02-28T20:30:58+00:00"
         },
         {
             "name": "openmage/magento-mirror",
@@ -597,7 +596,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2017-12-13 13:21:38"
+            "time": "2017-12-13T13:21:38+00:00"
         },
         {
             "name": "phan/phan",
@@ -656,7 +655,7 @@
                 "php",
                 "static"
             ],
-            "time": "2017-10-21 02:26:51"
+            "time": "2017-10-21T02:26:51+00:00"
         },
         {
             "name": "phing/phing",
@@ -749,7 +748,7 @@
                 "task",
                 "tool"
             ],
-            "time": "2018-01-25 13:18:09"
+            "time": "2018-01-25T13:18:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -803,7 +802,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11 18:02:19"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -848,7 +847,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10 14:09:06"
+            "time": "2017-11-10T14:09:06+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -895,7 +894,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14 14:27:02"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -961,7 +960,7 @@
                 "phpmd",
                 "pmd"
             ],
-            "time": "2017-01-20 14:41:10"
+            "time": "2017-01-20T14:41:10+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1010,7 +1009,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-02-20 10:12:59"
+            "time": "2019-02-20T10:12:59+00:00"
         },
         {
             "name": "psr/container",
@@ -1059,7 +1058,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14 16:28:37"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/log",
@@ -1106,7 +1105,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20 15:27:04"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "sabre/event",
@@ -1166,7 +1165,7 @@
                 "reactor",
                 "signal"
             ],
-            "time": "2018-03-05 13:55:47"
+            "time": "2018-03-05T13:55:47+00:00"
         },
         {
             "name": "sebastian/finder-facade",
@@ -1205,7 +1204,7 @@
             ],
             "description": "FinderFacade is a convenience wrapper for Symfony's Finder component.",
             "homepage": "https://github.com/sebastianbergmann/finder-facade",
-            "time": "2017-11-18 17:31:49"
+            "time": "2017-11-18T17:31:49+00:00"
         },
         {
             "name": "sebastian/phpcpd",
@@ -1256,7 +1255,7 @@
             ],
             "description": "Copy/Paste Detector (CPD) for PHP code.",
             "homepage": "https://github.com/sebastianbergmann/phpcpd",
-            "time": "2018-09-17 17:17:27"
+            "time": "2018-09-17T17:17:27+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1299,7 +1298,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1377,7 +1376,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-05-30 22:24:32"
+            "time": "2016-05-30T22:24:32+00:00"
         },
         {
             "name": "symfony/config",
@@ -1440,7 +1439,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23 15:17:42"
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
             "name": "symfony/console",
@@ -1512,7 +1511,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23 15:06:07"
+            "time": "2019-02-23T15:06:07+00:00"
         },
         {
             "name": "symfony/contracts",
@@ -1580,7 +1579,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2018-12-05 08:06:11"
+            "time": "2018-12-05T08:06:11+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1636,7 +1635,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-03 18:11:24"
+            "time": "2019-03-03T18:11:24+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -1709,7 +1708,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23 15:17:42"
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1759,7 +1758,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-07 11:40:08"
+            "time": "2019-02-07T11:40:08+00:00"
         },
         {
             "name": "symfony/finder",
@@ -1808,7 +1807,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23 15:42:05"
+            "time": "2019-02-23T15:42:05+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1867,7 +1866,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06 07:57:58"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1926,7 +1925,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23 15:17:42"
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
             "name": "theseer/fdomdocument",
@@ -1966,7 +1965,7 @@
             ],
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
-            "time": "2017-06-30 11:53:12"
+            "time": "2017-06-30T11:53:12+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2017,7 +2016,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25 11:19:39"
+            "time": "2018-12-25T11:19:39+00:00"
         },
         {
             "name": "wimg/php-compatibility",
@@ -2071,7 +2070,7 @@
                 "standards"
             ],
             "abandoned": "phpcompatibility/php-compatibility",
-            "time": "2018-07-17 13:42:26"
+            "time": "2018-07-17T13:42:26+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Description
Restores date published for a product and add feature flag for that.

## Related Issue
#507 

## How Has This Been Tested?
Bumped the SDK and checked if tagging has date published field.

## Documentation:

https://github.com/Nosto/nosto-magento/wiki/Configuring#add-product-published-date-to-tagging

## Checklist:
- [x] I have bumped the SDK
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
