### PR TITLE
Feature - Category sorting selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.10.0
+* Add Nosto category personalization in the default Magento category sorting options
+
 ### 3.9.0
 * Feature flag to set the a percentage of total PHP available memory that can be used by Nosto indexer
 * Exit indexer gracefully if the memory consumption goes over the predefined amount

--- a/app/code/community/Nosto/Tagging/Block/Product/List/Toolbar.php
+++ b/app/code/community/Nosto/Tagging/Block/Product/List/Toolbar.php
@@ -40,6 +40,7 @@ class Nosto_Tagging_Block_Product_List_Toolbar
      *
      * @param Varien_Data_Collection $collection
      * @return Mage_Catalog_Block_Product_List_Toolbar
+     * @throws Mage_Core_Model_Store_Exception
      */
     public function setCollection($collection)
     {
@@ -54,24 +55,23 @@ class Nosto_Tagging_Block_Product_List_Toolbar
             || !$accountHelper->find($store)
         ) {
             return parent::setCollection($collection);
-        } else {
-            $this->_collection = $collection;
-            $limit = (int)$this->getLimit();
-            if ($limit) {
-                $this->_collection->setPageSize($limit);
-            }
-            $this->_collection->setCurPage($this->getCurrentPage());
-            $sortIds = array_reverse($this->getSortIds($this->getCurrentOrder()));
-            if (!empty($sortIds)) {
-                $orderByIds = sprintf(
-                    'FIELD(product_id, %s) DESC',
-                    implode(',', $sortIds)
-                );
-                $this->_collection->getSelect()->order($orderByIds);
-            }
-
-            return $this;
         }
+        $this->_collection = $collection;
+        $limit = (int)$this->getLimit();
+        if ($limit) {
+            $this->_collection->setPageSize($limit);
+        }
+        $this->_collection->setCurPage($this->getCurrentPage());
+        $sortIds = array_reverse($this->getSortIds($this->getCurrentOrder()));
+        if (!empty($sortIds)) {
+            $orderByIds = sprintf(
+                'FIELD(product_id, %s) DESC',
+                implode(',', $sortIds)
+            );
+            $this->_collection->getSelect()->order($orderByIds);
+        }
+
+        return $this;
     }
 
     /**

--- a/app/code/community/Nosto/Tagging/Block/Product/List/Toolbar.php
+++ b/app/code/community/Nosto/Tagging/Block/Product/List/Toolbar.php
@@ -100,44 +100,4 @@ class Nosto_Tagging_Block_Product_List_Toolbar
             $type
         );
     }
-
-    /**
-     * Override parent method to set Nosto as default sorting option
-     *
-     * @return string
-     * @throws Exception
-     */
-    public function getCurrentOrder()
-    {
-        $order = $this->_getData('_current_grid_order');
-        if ($order) {
-            return $order;
-        }
-
-        $orders = $this->getAvailableOrders();
-        $nostoKey = Nosto_Tagging_Model_Category_Config::NOSTO_PERSONALIZED_KEY;
-        $defaultOrder = array_key_exists($nostoKey, $orders) ? $nostoKey : $this->_orderField ;
-
-        if (!isset($orders[$defaultOrder])) {
-            $keys = array_keys($orders);
-            $defaultOrder = $keys[0];
-        }
-
-        $order = $this->getRequest()->getParam($this->getOrderVarName());
-        if ($order && isset($orders[$order])) {
-            if ($order === $defaultOrder) {
-                Mage::getSingleton('catalog/session')->unsSortOrder();
-            } else {
-                $this->_memorizeParam('sort_order', $order);
-            }
-        } else {
-            $order = Mage::getSingleton('catalog/session')->getSortOrder();
-        }
-        // validate session value
-        if (!$order || !isset($orders[$order])) {
-            $order = $defaultOrder;
-        }
-        $this->setData('_current_grid_order', $order);
-        return $order;
-    }
 }

--- a/app/code/community/Nosto/Tagging/Block/Product/List/Toolbar.php
+++ b/app/code/community/Nosto/Tagging/Block/Product/List/Toolbar.php
@@ -100,4 +100,44 @@ class Nosto_Tagging_Block_Product_List_Toolbar
             $type
         );
     }
+
+    /**
+     * Override parent method to set Nosto as default sorting option
+     *
+     * @return string
+     * @throws Exception
+     */
+    public function getCurrentOrder()
+    {
+        $order = $this->_getData('_current_grid_order');
+        if ($order) {
+            return $order;
+        }
+
+        $orders = $this->getAvailableOrders();
+        $nostoKey = Nosto_Tagging_Model_Category_Config::NOSTO_PERSONALIZED_KEY;
+        $defaultOrder = array_key_exists($nostoKey, $orders) ? $nostoKey : $this->_orderField ;
+
+        if (!isset($orders[$defaultOrder])) {
+            $keys = array_keys($orders);
+            $defaultOrder = $keys[0];
+        }
+
+        $order = $this->getRequest()->getParam($this->getOrderVarName());
+        if ($order && isset($orders[$order])) {
+            if ($order === $defaultOrder) {
+                Mage::getSingleton('catalog/session')->unsSortOrder();
+            } else {
+                $this->_memorizeParam('sort_order', $order);
+            }
+        } else {
+            $order = Mage::getSingleton('catalog/session')->getSortOrder();
+        }
+        // validate session value
+        if (!$order || !isset($orders[$order])) {
+            $order = $defaultOrder;
+        }
+        $this->setData('_current_grid_order', $order);
+        return $order;
+    }
 }

--- a/app/code/community/Nosto/Tagging/Helper/Account.php
+++ b/app/code/community/Nosto/Tagging/Helper/Account.php
@@ -323,7 +323,7 @@ class Nosto_Tagging_Helper_Account extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * Returns all store views that have Nosto intsalled
+     * Returns all store views that have Nosto installed
      *
      * @return Mage_Core_Model_Store[]
      */
@@ -339,5 +339,19 @@ class Nosto_Tagging_Helper_Account extends Mage_Core_Helper_Abstract
         }
 
         return $storesWithNosto;
+    }
+
+    /**
+     * Returns the id of the fist store that has nosto installed
+     *
+     * @return int|null
+     */
+    public function getFirstNostoStoreId()
+    {
+        $storesWithNosto = $this->getAllStoreViewsWithNostoAccount();
+        if (!empty($storesWithNosto) && $storesWithNosto[0] instanceof Mage_Core_Model_Store) {
+            return $storesWithNosto[0]->getId();
+        }
+        return null;
     }
 }

--- a/app/code/community/Nosto/Tagging/Helper/Account.php
+++ b/app/code/community/Nosto/Tagging/Helper/Account.php
@@ -342,7 +342,7 @@ class Nosto_Tagging_Helper_Account extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * Returns the id of the fist store that has nosto installed
+     * Returns the id of the first store that has nosto installed
      *
      * @return int|null
      */

--- a/app/code/community/Nosto/Tagging/Model/Category/Config.php
+++ b/app/code/community/Nosto/Tagging/Model/Category/Config.php
@@ -40,14 +40,16 @@ class Nosto_Tagging_Model_Category_Config extends Mage_Catalog_Model_Config
     /**
      * Add relevance attribute as a sorting option
      *
+     * @param null $storeId
      * @return array
+     * @throws Mage_Core_Model_Store_Exception
      */
-    public function getAttributeUsedForSortByArray()
+    public function getAttributeUsedForSortByArray($storeId = null)
     {
         $options = parent::getAttributeUsedForSortByArray();
         /* @var Nosto_Tagging_Helper_Data $dataHelper */
         $dataHelper = Mage::helper('nosto_tagging');
-        $store = Mage::app()->getStore();
+        $store = Mage::app()->getStore($storeId);
         /* @var Nosto_Tagging_Helper_Account $accountHelper */
         $accountHelper = Mage::helper('nosto_tagging/account');
         $nostoAccount = $accountHelper->find($store);
@@ -56,7 +58,6 @@ class Nosto_Tagging_Model_Category_Config extends Mage_Catalog_Model_Config
             $featureAccessService = new Nosto_Service_FeatureAccess($nostoAccount);
             if ($dataHelper->getUsePersonalizedCategorySorting($store)
                 && $featureAccessService->canUseGraphql()
-
             ) {
                 $options[self::NOSTO_PERSONALIZED_KEY] = Mage::helper('catalog')->__('Personalized for you');
                 $options[self::NOSTO_TOPLIST_KEY] = Mage::helper('catalog')->__('Top products');

--- a/app/code/community/Nosto/Tagging/Model/Category/Sortby.php
+++ b/app/code/community/Nosto/Tagging/Model/Category/Sortby.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category  Nosto
+ * @package   Nosto_Tagging
+ * @author    Nosto Solutions Ltd <magento@nosto.com>
+ * @copyright Copyright (c) 2013-2019 Nosto Solutions Ltd (http://www.nosto.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Adds relevance attribute to the sorting options for category products
+ *
+ * @category Nosto
+ * @package  Nosto_Tagging
+ * @author   Nosto Solutions Ltd <magento@nosto.com>
+ */
+class Nosto_Tagging_Model_Category_Sortby extends Mage_Catalog_Model_Category_Attribute_Source_Sortby
+{
+    /**
+     * Retrieve All options
+     *
+     * @return array
+     */
+    public function getAllOptions()
+    {
+        if (is_null($this->_options)) {
+            $this->_options = array(array(
+                'label' => Mage::helper('catalog')->__('Best Value'),
+                'value' => 'position'
+            ));
+            foreach ($this->_getCatalogConfig()->getAttributesUsedForSortBy() as $attribute) {
+                $this->_options[] = array(
+                    'label' => Mage::helper('catalog')->__($attribute['frontend_label']),
+                    'value' => $attribute['attribute_code']
+                );
+            }
+        }
+        $this->_options[] = array(
+            'label' => 'Nosto',
+            'value' => 'NostoValue'
+        );
+        return $this->_options;
+    }
+}

--- a/app/code/community/Nosto/Tagging/Model/Category/Sortby.php
+++ b/app/code/community/Nosto/Tagging/Model/Category/Sortby.php
@@ -35,28 +35,29 @@
 class Nosto_Tagging_Model_Category_Sortby extends Mage_Catalog_Model_Category_Attribute_Source_Sortby
 {
     /**
-     * Retrieve All options
+     * Retrieve all options for category display settings product listing
      *
      * @return array
+     * @throws Mage_Core_Model_Store_Exception
      */
     public function getAllOptions()
     {
-        if (is_null($this->_options)) {
-            $this->_options = array(array(
-                'label' => Mage::helper('catalog')->__('Best Value'),
-                'value' => 'position'
-            ));
-            foreach ($this->_getCatalogConfig()->getAttributesUsedForSortBy() as $attribute) {
-                $this->_options[] = array(
-                    'label' => Mage::helper('catalog')->__($attribute['frontend_label']),
-                    'value' => $attribute['attribute_code']
-                );
-            }
+        /* @var Nosto_Tagging_Model_Category_Config $configModel*/
+        $configModel = Mage::getModel('nosto_tagging/category_config');
+        $storeId = (int)Mage::app()->getRequest()->getParam('store');
+        // If we're in 'All store views' scope, should show options if there's Nosto account
+        if ($storeId === Mage_Core_Model_App::ADMIN_STORE_ID) {
+            /* @var Nosto_Tagging_Helper_Account $accountHelper */
+            $accountHelper = Mage::helper('nosto_tagging/account');
+            $storeId = $accountHelper->getFirstNostoStoreId() ?: $storeId;
         }
-        $this->_options[] = array(
-            'label' => 'Nosto',
-            'value' => 'NostoValue'
-        );
+        $options = $configModel->getAttributeUsedForSortByArray($storeId);
+        foreach ($options as $key => $option) {
+            $this->_options[] = array(
+                'label' => $option,
+                'value' => $key
+            );
+        }
         return $this->_options;
     }
 }

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -102,6 +102,7 @@
             <catalog>
                 <rewrite>
                     <config>Nosto_Tagging_Model_Category_Config</config>
+                    <category_attribute_source_sortby>Nosto_Tagging_Model_Category_Sortby</category_attribute_source_sortby>
                 </rewrite>
             </catalog>
         </models>

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Nosto_Tagging>
-            <version>3.9.0</version>
+            <version>3.10.0</version>
         </Nosto_Tagging>
     </modules>
     <global>


### PR DESCRIPTION
## Description
Nosto category sorting options must be available in the default category sorting options. Currently, the sort options are only available in the actual category page.
This is now available at:
Catalog > Manage categories > Display settings

## Related Issue
Fixes #506 

## How Has This Been Tested?
Teste locally with 3 store views and category personalisation enabled/disabled.

## Documentation:
https://github.com/Nosto/nosto-magento/wiki/Configuring#category-sorting-experimental

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
