### PR TITLE
Category Personalization - Ignore product ids if they are not numeric

### DIFF
--- a/app/code/community/Nosto/Tagging/Model/Service/Recommendation/Category.php
+++ b/app/code/community/Nosto/Tagging/Model/Service/Recommendation/Category.php
@@ -57,32 +57,28 @@ class Nosto_Tagging_Model_Service_Recommendation_Category
         if (!$featureAccess->canUseGraphql()) {
             return $productIds;
         }
-        switch ($type){
-            case Nosto_Tagging_Model_Category_Config::NOSTO_PERSONALIZED_KEY:
-                $recoOperation = new Nosto_Operation_Recommendation_CategoryBrowsingHistory(
-                    $nostoAccount,
-                    $nostoCustomerId
-                );
-                break;
-            default:
-                $recoOperation = new Nosto_Operation_Recommendation_CategoryTopList(
-                    $nostoAccount,
-                    $nostoCustomerId
-                );
-                break;
+        if ($type === Nosto_Tagging_Model_Category_Config::NOSTO_PERSONALIZED_KEY) {
+            $recoOperation = new Nosto_Operation_Recommendation_CategoryBrowsingHistory(
+                $nostoAccount,
+                $nostoCustomerId
+            );
+        } else {
+            $recoOperation = new Nosto_Operation_Recommendation_CategoryTopList(
+                $nostoAccount,
+                $nostoCustomerId
+            );
         }
         $recoOperation->setCategory($category);
         try {
             $result = $recoOperation->execute();
             foreach ($result as $item) {
-                if ($item->getProductId()) {
+                if ($item->getProductId() && is_numeric($item->getProductId())) {
                     $productIds[] = $item->getProductId();
                 }
             }
         } catch (\Exception $e) {
             Nosto_Tagging_Helper_Log::exception($e);
         }
-
         return $productIds;
     }
 }


### PR DESCRIPTION
## Description
If Category Personalization GraphQL calls return products with non-numeric id's, they are no longer used for sorting.

## Related Issue
Closes #515 

## Motivation and Context
The sorting could crash if non-numeric product ids were used.

## How Has This Been Tested?
- Tested with preview mode enabled and mock products id's such as `nostomp1`.
- Tested with hardcoded non-numerical id's.

## Documentation:
N/A

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
