### PR TITLE
Hotfix 3.11.1 - Fix Add Multiple Products To Cart Javascript Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.11.1
+* Fix add multiple products to cart javascript function where some products added could have no image or link
+
 ### 3.11.0
 * Use mock products in category personalisation when preview mode is enabled
 * Ignore non-numeric product ids in Graphql responses

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Nosto_Tagging>
-            <version>3.11.0</version>
+            <version>3.11.1</version>
         </Nosto_Tagging>
     </modules>
     <global>

--- a/app/design/frontend/base/default/template/nostotagging/addtocart.phtml
+++ b/app/design/frontend/base/default/template/nostotagging/addtocart.phtml
@@ -63,16 +63,9 @@ $formKey = $session->getFormKey();
 
     // Products must be and array of objects [{productId: "123", skuId: "321"}]
     Nosto.addMultipleProductsToCart = function (products, element) {
-        var skus = [];
         products.forEach(function(product) {
-            Nosto.trackAddToCartClick(product.productId, element);
-            skus.push(product.skuId);
+            Nosto.addSkuToCart(product, element, 1);
         });
-        var fields = {};
-        fields["product"] = skus.pop();
-        fields["related_product"] = skus;
-        fields["form_key"]= "<?php echo $formKey; ?>";
-        Nosto.postAddToCartForm(fields, "<?php echo $formAction; ?>");
     };
 
     // Product object must have fields productId and skuId {productId: 123, skuId: 321}


### PR DESCRIPTION
## Description
Fixes an error on the add multiple products to cart javascript function, where the SKU would be added instead of the parent configurable product with super attributes.

## Related Issue
Fixes #528

## Motivation and Context
In some setups, the added product can have no image or link to the product page.

## How Has This Been Tested?
Run 
```
Nosto.addMultipleProductsToCart([
        {'productId' : '425', 'skuId' : '310'},
		{'productId' : '425', 'skuId' : '314'},
		{'productId' : '425', 'skuId' : '312'},
		{'productId' : '425', 'skuId' : '313'},
    ], this);
```
And observe that the products are correctly added to cart with images and links to the product page.

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
