### PR TITLE
Remove String typehint in URL helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.11.3
+* Remove function parameter type check for compatibility with PHP > 5.6
+
 ### 3.11.2
 * Implement new add multiple products to cart method to fix cart products having no image
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
 ### 3.11.3
-* Remove function parameter type check for compatibility with PHP > 5.6
+* Remove function parameter type check for compatibility with PHP < 5.6
 
 ### 3.11.2
 * Implement new add multiple products to cart method to fix cart products having no image

--- a/app/code/community/Nosto/Tagging/Helper/Url.php
+++ b/app/code/community/Nosto/Tagging/Helper/Url.php
@@ -571,10 +571,10 @@ class Nosto_Tagging_Helper_Url extends Mage_Core_Helper_Abstract
     /**
      * Wrapper that returns URL with action in add to cart controller
      * @param Mage_Core_Model_Store $store
-     * @param String $action
+     * @param $action
      * @return string
      */
-    protected function getAddToCartUrlByAction(Mage_Core_Model_Store $store, String $action)
+    protected function getAddToCartUrlByAction(Mage_Core_Model_Store $store, $action)
     {
         $defaultParams = $this->getUrlOptionsWithNoSid($store);
         $defaultParams[self::MAGENTO_URL_OPTION_SECURE] = 1;

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Nosto_Tagging>
-            <version>3.11.2</version>
+            <version>3.11.3</version>
         </Nosto_Tagging>
     </modules>
     <global>


### PR DESCRIPTION
## Description
Remove wrongful method parameter type which is incompatible with PHP < 5.6

## Related Issue
Closes #528 
## How Has This Been Tested?

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
