### PR TITLE
Hotfix 3.11.4 - Add category tagging to product tagging & Fix hidden categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 3.11.4
+* Fix category tagging not being rendered on product detail page
+* Fix an issue when rendering category tagging for categories in which parents are hidden
+
 ### 3.11.3
 * Remove function parameter type check for compatibility with PHP < 5.6
 

--- a/app/code/community/Nosto/Tagging/Block/Category.php
+++ b/app/code/community/Nosto/Tagging/Block/Category.php
@@ -70,7 +70,10 @@ class Nosto_Tagging_Block_Category extends Mage_Core_Block_Template
     {
         try {
             $category = Mage::registry('current_category');
-            return Nosto_Tagging_Model_Meta_Category_Builder::build($category);
+            if ($category) {
+                return Nosto_Tagging_Model_Meta_Category_Builder::build($category);
+            }
+            return null;
         } catch (\Exception $e) {
             Nosto_Tagging_Helper_Log::exception($e);
             return null;

--- a/app/code/community/Nosto/Tagging/Helper/Data.php
+++ b/app/code/community/Nosto/Tagging/Helper/Data.php
@@ -265,12 +265,10 @@ class Nosto_Tagging_Helper_Data extends Mage_Core_Helper_Abstract
             $categories = $category->getParentCategories();
             $path = $category->getPathInStore();
             $ids = array_reverse(explode(',', $path));
+            $data = array();
             foreach ($ids as $id) {
                 if (isset($categories[$id]) && $categories[$id]->getName()) {
                     $data[] = $categories[$id]->getName();
-                } else {
-                    $data = array();
-                    break;
                 }
             }
         }

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Nosto_Tagging>
-            <version>3.11.3</version>
+            <version>3.11.4</version>
         </Nosto_Tagging>
     </modules>
     <global>

--- a/app/design/frontend/base/default/layout/nostotagging.xml
+++ b/app/design/frontend/base/default/layout/nostotagging.xml
@@ -85,6 +85,7 @@
     <catalog_product_view>
         <reference name="after_body_start">
             <block type="nosto_tagging/product" name="nosto.product"/>
+            <block type="nosto_tagging/category" name="nosto.category"/>
         </reference>
     </catalog_product_view>
 


### PR DESCRIPTION
## Description
Fixes two issues:
- Category tagging not being rendered on PDP.
- Add the possibility to render category tagging for categories in which parents are hidden categories.

## Related Issue
Closes #544 
Closes #543 

## How Has This Been Tested?
- [x] Tested with Magento 1.9

## Documentation:
N/A

## Possible caveats
- Now child categories are treated as root if the parent is hidden. Which is the same behavior as Magento breadcrumbs. (Which makes sense, since the parent is hidden and inactive)


## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non-existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
