### PR TITLE
Bugfix - remove category string double encoding

### DIFF
--- a/app/code/community/Nosto/Tagging/Model/Meta/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Meta/Product.php
@@ -48,15 +48,6 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Object_Product_Product
     protected $_tags = array();
 
     /**
-     * Backwards compatibility for categories
-     *
-     * @deprecated Use setters instead of direct assignment. This attribute will
-     * be removed in future release.
-     * @var array
-     */
-    protected $_categories = array();
-
-    /**
      * Array of deprecated direct attribute assignments
      *
      * @var array
@@ -599,22 +590,6 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Object_Product_Product
         }
 
         return $tags;
-    }
-
-    /**
-     * @inheritdoc
-     * @suppress PhanDeprecatedProperty
-     */
-    public function getCategories()
-    {
-        $categories = parent::getCategories();
-        /** @noinspection PhpDeprecationInspection */
-        if (!empty($this->_categories)) {
-            /** @noinspection PhpDeprecationInspection */
-            $categories = array_merge($categories, $this->_categories);
-        }
-
-        return $categories;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When building the product data the category string was encoded twice.

## Related Issue
closed #546

## How Has This Been Tested?
Manually

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [ ] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
