### PR TITLE
Add google category as customisable attribute

### DIFF
--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Run Phan analysis
       id: phan-analysis
-      run: ./vendor/bin/phan --config-file=phan.php --output-mode=checkstyle --output=chkphan.xml --processes=4
+      run: ./vendor/bin/phan --config-file=phan.php --output-mode=checkstyle --output=chkphan.xml
       continue-on-error: true
 
     - name: Archive static analysis results

--- a/app/code/community/Nosto/Tagging/Model/Meta/Product.php
+++ b/app/code/community/Nosto/Tagging/Model/Meta/Product.php
@@ -633,7 +633,11 @@ class Nosto_Tagging_Model_Meta_Product extends Nosto_Object_Product_Product
      */
     protected function getCustomisableAttributes()
     {
-        return array('gtin' => 'gtin', 'supplier_cost' => 'supplierCost');
+        return array(
+            'gtin' => 'gtin',
+            'supplier_cost' => 'supplierCost',
+            'google_category' => 'googleCategory'
+        );
     }
 
     /**

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -245,6 +245,7 @@
             </brand_attribute>
             <attribute_map>
                 <gtin>0</gtin>
+                <google_category>0</google_category>
                 <supplier_cost>cost</supplier_cost>
             </attribute_map>
             <ratings_and_reviews>

--- a/app/code/community/Nosto/Tagging/etc/system.xml
+++ b/app/code/community/Nosto/Tagging/etc/system.xml
@@ -311,6 +311,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </supplier_cost>
+                        <google_category translate="label">
+                            <label>Google Category</label>
+                            <comment>Choose attribute that will be used as google category attribute for Nosto product tagging</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>nosto_tagging/system_config_source_product_attribute</source_model>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </google_category>
                     </fields>
                 </attribute_map>
                 <multi_currency translate="label">


### PR DESCRIPTION
## Description
Adds missing `google_category` attribute to tagging

## Related Issue
Closes #552

## Motivation and Context
N/A

## How Has This Been Tested?
Enable the flag on the config, reindex a product and should show up on Nosto's backend

## Documentation:
N/A

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] I have assigned the correct milestone or created one if non existent.
- [X] I have correctly labeled this pull request.
- [X] I have linked the corresponding issue in this description.
- [X] I have updated the corresponding Jira ticket.
- [X] I have requested a review from at least 2 reviewers
- [X] I have checked the base branch of this pull request
- [X] I have checked my code for any possible security vulnerabilities
