### PR TITLE
Check Nosto cookie before settings the add to cart cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+### 4.1.1
+* Send add to cart cookies only if Nosto's cookie is present
+
 ### 4.1.0
 * Add google category as customisable attribute
 

--- a/app/code/community/Nosto/Tagging/.env
+++ b/app/code/community/Nosto/Tagging/.env
@@ -1,1 +1,6 @@
-/Users/hannu.polonen/Sites/Libs/.env-my-dev
+NOSTO_SERVER_URL=connect.nosto.com
+NOSTO_API_BASE_URL=https://api.nosto.com
+NOSTO_OAUTH_BASE_URL=https://my.nosto.com/oauth
+NOSTO_WEB_HOOK_BASE_URL=https://my.nosto.com
+NOSTO_IFRAME_ORIGIN_REGEXP=(https:\/\/(.*)\.hub\.nosto\.com)|(https:\/\/my\.nosto\.com)
+NOSTO_PRODUCT_API_WAIT_TIMEOUT=120

--- a/app/code/community/Nosto/Tagging/.env
+++ b/app/code/community/Nosto/Tagging/.env
@@ -1,6 +1,1 @@
-NOSTO_SERVER_URL=connect.nosto.com
-NOSTO_API_BASE_URL=https://api.nosto.com
-NOSTO_OAUTH_BASE_URL=https://my.nosto.com/oauth
-NOSTO_WEB_HOOK_BASE_URL=https://my.nosto.com
-NOSTO_IFRAME_ORIGIN_REGEXP=(https:\/\/(.*)\.hub\.nosto\.com)|(https:\/\/my\.nosto\.com)
-NOSTO_PRODUCT_API_WAIT_TIMEOUT=120
+/Users/hannu.polonen/Sites/Libs/.env-my-dev

--- a/app/code/community/Nosto/Tagging/Model/Observer/Cart.php
+++ b/app/code/community/Nosto/Tagging/Model/Observer/Cart.php
@@ -89,11 +89,10 @@ class Nosto_Tagging_Model_Observer_Cart
             $addedItem = Nosto_Tagging_Model_Meta_Cart_Builder::buildItem($quoteItem, $currencyCode);
             $cartUpdate->setAddedItems(array($addedItem));
 
+            /** @var Mage_Core_Model_Cookie $cookie */
+            $cookie = Mage::getModel('core/cookie');
             //set the cookie to trigger add to cart event
-            if (!headers_sent()) {
-                /** @var Mage_Core_Model_Cookie $cookie */
-                $cookie = Mage::getModel('core/cookie');
-
+            if (!headers_sent() && !empty($cookie->get(Nosto_Tagging_Helper_Data::COOKIE_NAME))) {
                 $cookie->set(
                     self::COOKIE_NAME,
                     Nosto_Helper_SerializationHelper::serialize($cartUpdate),
@@ -104,7 +103,7 @@ class Nosto_Tagging_Model_Observer_Cart
                     false
                 );
             } else {
-                NostoLog::info('Headers sent already. Cannot set the cookie.');
+                NostoLog::info('Headers sent already or no Nosto cookie available. Cannot set the cookie.');
             }
 
             if ($dataHelper->getSendAddToCartEvent($store)) {

--- a/app/code/community/Nosto/Tagging/etc/config.xml
+++ b/app/code/community/Nosto/Tagging/etc/config.xml
@@ -28,7 +28,7 @@
 <config>
     <modules>
         <Nosto_Tagging>
-            <version>4.1.0</version>
+            <version>4.1.1</version>
         </Nosto_Tagging>
     </modules>
     <global>


### PR DESCRIPTION
## Description
Check that Nosto cookie is present before sending add to cart cookie. 

## Related Issue
#557 

## Motivation and Context
The cookie setting is redundant if Nosto is not aware of the current visitor. 

## How Has This Been Tested?
Tested locally with and without the cookie.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] I have assigned the correct milestone or created one if non existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [x] I have updated the corresponding Jira ticket.
- [x] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
